### PR TITLE
Reopening a PR triggers labeling rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const ignore = require('ignore')
 
 module.exports = robot => {
   robot.on('pull_request.opened', autolabel)
-  robot.on('pull_request.synchronize', autolabel)
   robot.on('pull_request.reopened', autolabel)
+  robot.on('pull_request.synchronize', autolabel)
 
   async function autolabel (context) {
     const content = await context.github.repos.getContent(context.repo({

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const ignore = require('ignore')
 module.exports = robot => {
   robot.on('pull_request.opened', autolabel)
   robot.on('pull_request.synchronize', autolabel)
+  robot.on('pull_request.reopened', autolabel)
 
   async function autolabel (context) {
     const content = await context.github.repos.getContent(context.repo({


### PR DESCRIPTION
In order to coerce `autolabeler` into triggering on PRs which were opened _before_ the labeling rules were setup, a repo admin should be able to close/re-open a PR in order to get `autolabeler` to apply labeling rules.

tl;dr, this triggers labeling rules when a PR has been closed and then reopened, rather than _only_ the first time a PR was opened.

p.s., apologies for sloppy commit messages. I can definitely fix them up if desired.