### PR TITLE
fix: retrieve pr files

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = ({ app }) => {
       Buffer.from(content.data.content, 'base64').toString()
     )
 
-    const files = await context.octokit.pulls.listFiles(context.issue())
+    const files = await context.octokit.pulls.listFiles(context.pullRequest())
     const changedFiles = files.data.map((file) => file.filename)
 
     const labels = new Set()

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
       "pre-commit": "lint-staged"
     }
   },
+  "jest": {
+    "verbose": true,
+    "testURL": "http://localhost/"
+  },
   "engines": {
     "node": ">= 10.9.0",
     "npm": ">= 6.0.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,7 +40,7 @@ describe('autolabeler', () => {
         .reply(200, {
           content: Buffer.from(config, 'utf-8').toString('base64')
         })
-        .get('/repos/robotland/test/pulls//files?issue_number=98')
+        .get('/repos/robotland/test/pulls/98/files')
         .reply(200, [
           { filename: 'test.txt' },
           { filename: '.github/autolabeler.yml' }


### PR DESCRIPTION
 ## Content 
Use the context PR data instead of issue. Like the app listens the PR events, it makes sens now to use PR data instead the issue. I think the final endpoint is inferred by the used context data. Now the endpoint seems aligned with the API one and the unit test verifies the change.

https://docs.github.com/en/free-pro-team@latest/rest/reference/pulls#list-pull-requests-files


issue #60 