### PR TITLE
test: update test with new Github API labels 🧪

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,7 +46,7 @@ describe('autolabeler', () => {
           { filename: '.github/autolabeler.yml' }
         ])
         .post('/repos/robotland/test/issues/98/labels', (body) => {
-          expect(body).toEqual(['test', 'config'])
+          expect(body).toEqual({ labels: ['test', 'config'] })
           return true
         })
         .reply(200)


### PR DESCRIPTION
Following issue #66 

<img width="588" alt="Screenshot 2023-10-03 at 20 30 56" src="https://github.com/mithro/autolabeler/assets/3717296/08b8b162-c8d1-4df6-bc07-f9a2de8283e2">